### PR TITLE
adding missing / to request_uri

### DIFF
--- a/src/modules/auth/services/oidc.ts
+++ b/src/modules/auth/services/oidc.ts
@@ -14,7 +14,7 @@ const manager = new UserManager({
   client_secret: oidcSetting.client_secret,
   scope: oidcSetting.scope,
   response_type: 'code',
-  redirect_uri: `${window.location.origin}${config.appContext}oidc/callback`,
+  redirect_uri: `${window.location.origin}${config.appContext}/oidc/callback`,
   post_logout_redirect_uri: `${window.location.origin}${window.location.pathname}`,
   loadUserInfo: oidcSetting.loadUserInfo,
 });


### PR DESCRIPTION
A slash is missing in the redirect_uri that leads to an incorrect uri in the callback to the oidc provider.